### PR TITLE
予定と候補の表示テストを実装

### DIFF
--- a/test/test.js
+++ b/test/test.js
@@ -64,7 +64,12 @@ describe('/schedules', () => {
           let createdSchedulePath = res.headers.location;
           request(app)
             .get(createdSchedulePath)
-            // TODO 作成された予定と候補が表示されていることをテストする
+            .expect(/テスト予定1/)
+            .expect(/テストメモ1/)
+            .expect(/テストメモ2/)
+            .expect(/テスト候補1/)
+            .expect(/テスト候補2/)
+            .expect(/テスト候補3/)
             .expect(200)
             .end(() => {
               // テストで作成したデータを削除


### PR DESCRIPTION
練習用プルリクエストのためマージ不要
postgresqlではカラム名などは英数小文字推奨らしく、スペルミスでuserNameとしていたカラム名の変更ができませんでした。実装初期に気づけたためデータベースの作り直しができましたが、ユーザ数が増えていたらと思うと背筋が冷えますね。